### PR TITLE
You must target the head to throw a hat on someone's head

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -43,6 +43,7 @@ SUBSYSTEM_DEF(throwing)
 	var/atom/movable/thrownthing
 	var/atom/target
 	var/turf/target_turf
+	var/target_zone
 	var/init_dir
 	var/maxrange
 	var/speed

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -526,6 +526,8 @@
 	TT.diagonals_first = diagonals_first
 	TT.force = force
 	TT.callback = callback
+	if(!QDELETED(thrower))
+		TT.target_zone = thrower.zone_selected
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -30,8 +30,10 @@
 		var/mob/M = loc
 		M.update_inv_head()
 
-/obj/item/clothing/head/throw_impact(atom/hit_atom)
+/obj/item/clothing/head/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)
 	..()
+	if(thrownthing.target_zone && thrownthing.target_zone != BODY_ZONE_HEAD)
+		return
 	if(iscarbon(hit_atom))
 		var/mob/living/carbon/H = hit_atom
 		if(H.head)


### PR DESCRIPTION
Targeting anything else will shortcut the hat on head logic and nothing special will happen.

If you prefer I can cause this to be eyes, mouth, or head, but right now it's specifically the head.